### PR TITLE
Add placeholder.list

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,11 @@ ember install ember-content-placeholders
 
 * yield `placeholder.nav`
 
+
+* yield `placeholder.list`
+  * Boolean `ordered` (default: false)
+
 **TO DO:**
-- `placeholder.list`
 - `placeholder.chart`
 - `placeholder.table`
 

--- a/addon/components/content-placeholders-list.js
+++ b/addon/components/content-placeholders-list.js
@@ -1,0 +1,17 @@
+import { computed, get } from '@ember/object';
+import ContentPlaceholersBase from './content-placeholders-base';
+import layout from '../templates/components/content-placeholders-list';
+
+export default ContentPlaceholersBase.extend({
+  layout,
+
+  className: 'ember-content-placeholders-list',
+  classNameBindings: ['className'],
+
+  ordered: false,
+
+  items: 4,
+  itemsArray: computed('items', function() {
+    return Array.apply(null, Array(get(this, 'items')));
+  }),
+});

--- a/addon/templates/components/content-placeholders-list.hbs
+++ b/addon/templates/components/content-placeholders-list.hbs
@@ -1,0 +1,13 @@
+{{#if ordered}}
+  <ol>
+    {{#each itemsArray}}
+      <li class="{{className}}__item" data-test-ember-content-placeholders-list-item>&#8203;<div></div></li>
+    {{/each}}
+  </ol>
+{{else}}
+  <ul>
+    {{#each itemsArray}}
+      <li class="{{className}}__item" data-test-ember-content-placeholders-list-item>&#8203;<div></div></li>
+    {{/each}}
+  </ul>
+{{/if}}

--- a/addon/templates/components/content-placeholders.hbs
+++ b/addon/templates/components/content-placeholders.hbs
@@ -27,5 +27,13 @@
       animated=animated
       centered=centered
     )
+
+    list=(
+      component 'content-placeholders-list'
+      rounded=rounded
+      animated=animated
+      centered=centered
+      ordered=ordered
+    )
   )
 }}

--- a/app/components/content-placeholders-list.js
+++ b/app/components/content-placeholders-list.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-content-placeholders/components/content-placeholders-list';

--- a/app/styles/ember-content-placeholders.scss
+++ b/app/styles/ember-content-placeholders.scss
@@ -158,3 +158,37 @@ $ember-content-placeholders-spacing: 10px !default;
     }
   }
 }
+
+.ember-content-placeholders-list {
+  @include ember-content-placeholders-spacing;
+
+  &__item {
+      position: relative;
+
+      div {
+        @include ember-content-placeholders;
+        position: absolute;
+        height: initial;
+        top: 0.25em;
+        bottom: 0.25em;
+        left: 0;
+        right: 0;
+      }
+
+    &:nth-child(4n + 1) {
+      width: 80%;
+    }
+
+    &:nth-child(4n + 2) {
+      width: 100%;
+    }
+
+    &:nth-child(4n + 3) {
+      width: 70%;
+    }
+
+    &:nth-child(4n + 4) {
+      width: 85%;
+    }
+  }
+}

--- a/tests/integration/components/content-placeholders-list-test.js
+++ b/tests/integration/components/content-placeholders-list-test.js
@@ -1,0 +1,38 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('content-placeholders-list', 'Integration | Component | content placeholders list', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+  this.render(hbs`
+    {{content-placeholders-list items=6}}
+  `);
+
+  assert.equal(this.$('[data-test-ember-content-placeholders-list-item]').length, 6, 'it renders 6 items');
+});
+
+test('it renders an unordered list by default', function(assert) {
+  this.render(hbs`
+    {{content-placeholders-list}}
+  `);
+
+  assert.ok(this.$('ul > [data-test-ember-content-placeholders-list-item]').length, 'ul rendered');
+});
+
+test('it renders an unordered list when ordered=false', function(assert) {
+  this.render(hbs`
+    {{content-placeholders-list ordered=false}}
+  `);
+
+  assert.ok(this.$('ul > [data-test-ember-content-placeholders-list-item]').length, 'ul rendered');
+});
+
+test('it renders an ordered list when ordered=true', function(assert) {
+  this.render(hbs`
+    {{content-placeholders-list ordered=true}}
+  `);
+
+  assert.ok(this.$('ol > [data-test-ember-content-placeholders-list-item]').length, 'ol rendered');
+});


### PR DESCRIPTION
This adds a `placeholder.list` yielded component.

For this component, the placeholder height is relative to font size rather than a fixed height. This is achieved by placing a zero-width space in the `li` and absolutely positioning the placeholder `div` within the `li` with 0.25em top and bottom margins.

Also, `$ember-content-placeholders-spacing` is not used.